### PR TITLE
fix: env variable name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM node:16
 WORKDIR /usr/src/app
 
 # Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
 COPY package.json yarn.lock ./
 
 RUN yarn install --pure-lockfile

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,7 +7,7 @@ const baseConfig = {
   env,
   isDev: env === "development",
   isTest: env === "testing",
-  port: process.env.PORT ?? 3000,
+  port: process.env.FILECOIN_DBS_PORT ?? 3000,
   privateKey: process.env.PRIVATE_KEY,
   dbsUrl: process.env.DBS_URL,
   locationUrl: process.env.LOCATION_URL,


### PR DESCRIPTION
Fixes nothing

Changes proposed in this PR:

- Just switching from using a PORT environment variable to FILECOIN_DBS_PORT to avoid collision with other services when mounting my docker-compose configuration.